### PR TITLE
Support unnamed args in target()

### DIFF
--- a/R/ui.R
+++ b/R/ui.R
@@ -66,6 +66,7 @@ commands_batch = function(x = NULL) {
 #' @title Function \code{targets}
 #' @description Puts a named collection of data frames of \code{remake} 
 #' commands all together to make a YAML-like list of targets.
+#' Unnamed arguments are permitted for data frames with exactly one row.
 #' Targets \code{"all"}, \code{"clean"}, and \code{"target_name"},  
 #' are already used by \code{remake} and cannot be overwritten by the user.
 #' In addition, all target names must be unique. For instance,

--- a/R/utils.R
+++ b/R/utils.R
@@ -23,10 +23,15 @@ check_target_names = function(target_names){
     msg = paste0("Prohibited target names include ", msg, ".")
     stop(msg)
   }
-  if(anyDuplicated(target_names)) stop("Targets must have unique names. 
-    In addition, targets(x = my_data_drame) is prohibited if \"x\"
-    is an element of my_data_frame$target. The target 
-    name \"all\" is reserved and similarly prohibited.")
+  if(anyDuplicated(target_names)) {
+    msg = paste(target_names[duplicated(target_names)], collapse = ", ")
+    stop("Targets must have unique names. Offending targets:
+      ", msg,
+    ". In addition, targets(x = my_data_drame) is prohibited if \"x\"
+    is an element of my_data_frame$target. (You can omit x = for data
+    frames consisting of exactly one row.) The target name \"all\" is
+    reserved and similarly prohibited.")
+  }
 }
 
 #' @title Function \code{clean_stages}


### PR DESCRIPTION
Must be data frames of one row length. This is useful for targets created by `gather()`, yields simpler rules.

Also adds list of offending targets to the "duplicate targets" error message.