### PR TITLE
Invisibly return the data.frame in assert_commands

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -8,6 +8,7 @@ assert_commands = function(x){
   if(is.null(x$target) | any(!nchar(x$target)) | any(!nchar(x$command))) 
     stop("All commands and their targets must be given. For example, write commands(x = data(y), z = 3) instead of commands(x, z) or commands(data(y), 3).")
   if(anyDuplicated(x$target)) stop("Commands must be given unique target names. No duplicate names allowed.")
+  invisible(x)
 }
 
 #' @title Function \code{check_target_names}

--- a/tests/testthat/test-assert_commands.R
+++ b/tests/testthat/test-assert_commands.R
@@ -5,6 +5,6 @@ source("utils.R")
 test_that("Function assert_commands() is correct.", {
   testwd("assert_commands")
   expect_error(assert_commands())
-  expect_equal(assert_commands(commands(x = 1, y = f(2))), NULL)
+  expect_equal(assert_commands(commands(x = 1, y = f(2))), commands(x = 1, y = f(2)))
   testrm("assert_commands")
 })


### PR DESCRIPTION
This way, I can build my own commands using data.frame making commands I'm comfortable with (i.e. tribble instead of commands_batch) and check they're OK in a pipe.